### PR TITLE
fix: cannot login as gapi returns unique key, value for userinfo

### DIFF
--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -58,9 +58,10 @@ function Login() {
   }, [gapi]);
 
   async function responseGoogle(result) {
-    const name = result.Ju.sf;
-    const userEmail = result.Ju.zv;
-    const googleLoginUser = gapi.auth2.getAuthInstance().currentUser.get();
+    const googleLoginUser = result;
+    const profile = googleLoginUser.getBasicProfile();
+    const name = profile.getName();
+    const userEmail = profile.getEmail();
 
     const serverResponse = await axios.post(
       `${process.env.REACT_APP_BASE_URL}/auth/login`,

--- a/src/features/user/userSlice.js
+++ b/src/features/user/userSlice.js
@@ -18,6 +18,7 @@ export const userSlice = createSlice({
         action.payload;
 
       return {
+        ...initialState,
         id,
         username,
         email,


### PR DESCRIPTION
# fix: cannot login as gapi returns unique key, value for userinfo

## 수정 사항
-  https://github.com/polar-town/polar-town-frontend/pull/6/files 코드 pull 진행시 로그인이 되지 않는 이슈 발생
- 원인은 구글인증 후 넘어오는 response 객체의 key가 유니크해서 BasicProfile.getEmail(), BasicProfile.getName()로 서버에 넘겨주는 정보를 받아와야 함