### PR TITLE
Feature/loginpersist

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,5 +1,5 @@
+import axios from "axios";
 import useGapi from "../hooks/useGapi";
-import instance from "./interceptor";
 
 export async function checkUserLoginStatus() {
   const gapi = useGapi();
@@ -8,7 +8,7 @@ export async function checkUserLoginStatus() {
 
   if (isLogedIn) {
     try {
-      const response = await instance.get(
+      const response = await axios.get(
         `${process.env.REACT_APP_SERVER_URL}/auth/refresh`
       );
 

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,5 +1,5 @@
-import axios from "axios";
 import useGapi from "../hooks/useGapi";
+import getAccessToken from "../utils/accessToken";
 
 export async function checkUserLoginStatus() {
   const gapi = useGapi();
@@ -8,11 +8,7 @@ export async function checkUserLoginStatus() {
 
   if (isLogedIn) {
     try {
-      const response = await axios.get(
-        `${process.env.REACT_APP_SERVER_URL}/auth/refresh`
-      );
-
-      return response.data;
+      return await getAccessToken();
     } catch (err) {
       console.error(err);
     }

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -3,8 +3,7 @@ import getAccessToken from "../utils/accessToken";
 
 export async function checkUserLoginStatus() {
   const gapi = useGapi();
-  const GoogleAuth = gapi.auth2.getAuthInstance();
-  const isLogedIn = GoogleAuth.isSignedIn.get();
+  const isLogedIn = gapi.auth2.getAuthInstance().isSignedIn.get();
 
   if (isLogedIn) {
     try {

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,0 +1,20 @@
+import useGapi from "../hooks/useGapi";
+import instance from "./interceptor";
+
+export async function checkUserLoginStatus() {
+  const gapi = useGapi();
+  const GoogleAuth = gapi.auth2.getAuthInstance();
+  const isLogedIn = GoogleAuth.isSignedIn.get();
+
+  if (isLogedIn) {
+    try {
+      const response = await instance.get(
+        `${process.env.REACT_APP_SERVER_URL}/auth/refresh`
+      );
+
+      return response.data;
+    } catch (err) {
+      console.error(err);
+    }
+  }
+}

--- a/src/api/interceptor.js
+++ b/src/api/interceptor.js
@@ -14,7 +14,7 @@ const instance = axios.create({
 instance.interceptors.request.use(
   (config) => {
     if (!config.headers["Authorization"]) {
-      config.headers["Authorization"] = `Barearer ${currentUserAccessToken}`;
+      config.headers["Authorization"] = `Bearer ${currentUserAccessToken}`;
     }
 
     return config;
@@ -30,10 +30,12 @@ instance.interceptors.response.use(
   },
   async (err) => {
     const originalRequest = err.config;
+
     if (err.response.status === 401 && !originalRequest._retry) {
-      originalRequest._retry = true;
       const newAccessToken = await getAccessToken();
-      originalRequest.headers["Authorization"] = `Barearer ${newAccessToken}`;
+
+      originalRequest._retry = true;
+      originalRequest.headers["Authorization"] = `Bearer ${newAccessToken}`;
 
       return instance(originalRequest);
     }

--- a/src/api/interceptor.js
+++ b/src/api/interceptor.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { useSelector } from "react-redux";
 import { selectUserToken } from "../features/user/userSlice";
-import useRefreshToken from "../utils/getAccessToken";
+import getAccessToken from "../utils/accessToken";
 
 const currentUserAccessToken = useSelector(selectUserToken);
 
@@ -21,7 +21,7 @@ instance.interceptors.request.use(
   },
   (err) => {
     return Promise.reject(err);
-  },
+  }
 );
 
 instance.interceptors.response.use(
@@ -32,14 +32,14 @@ instance.interceptors.response.use(
     const originalRequest = err.config;
     if (err.response.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true;
-      const newAccessToken = await useRefreshToken();
+      const newAccessToken = await getAccessToken();
       originalRequest.headers["Authorization"] = `Barearer ${newAccessToken}`;
 
       return instance(originalRequest);
     }
 
     return Promise.reject(err);
-  },
+  }
 );
 
 export default instance;

--- a/src/api/interceptor.js
+++ b/src/api/interceptor.js
@@ -1,0 +1,45 @@
+import axios from "axios";
+import { useSelector } from "react-redux";
+import { selectUserToken } from "../features/user/userSlice";
+import useRefreshToken from "../utils/getAccessToken";
+
+const currentUserAccessToken = useSelector(selectUserToken);
+
+const instance = axios.create({
+  baseURL: process.env.REACT_APP_BASE_URL,
+  headers: { "Content-Type": "application/json" },
+  withCredentials: true,
+});
+
+instance.interceptors.request.use(
+  (config) => {
+    if (!config.headers["Authorization"]) {
+      config.headers["Authorization"] = `Barearer ${currentUserAccessToken}`;
+    }
+
+    return config;
+  },
+  (err) => {
+    return Promise.reject(err);
+  },
+);
+
+instance.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  async (err) => {
+    const originalRequest = err.config;
+    if (err.response.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      const newAccessToken = await useRefreshToken();
+      originalRequest.headers["Authorization"] = `Barearer ${newAccessToken}`;
+
+      return instance(originalRequest);
+    }
+
+    return Promise.reject(err);
+  },
+);
+
+export default instance;

--- a/src/api/refreshToken.js
+++ b/src/api/refreshToken.js
@@ -11,7 +11,7 @@ async function verifyRefreshToken(email) {
   try {
     return await getAccessToken();
   } catch (err) {
-    if (err.responce.status === 403) {
+    if (err.response.status === 403) {
       try {
         await axios.post(`${process.env.REACT_APP_SERVER_URL}/auth/logout`, {
           email,

--- a/src/api/refreshToken.js
+++ b/src/api/refreshToken.js
@@ -1,0 +1,35 @@
+import axios from "axios";
+import { useNavigate } from "react-router-dom";
+import useGapi from "../hooks/useGapi";
+
+async function verifyRefreshToken(email) {
+  const navigate = useNavigate();
+  const gapi = useGapi();
+  const GoogleAuth = gapi.auth2.getAuthInstance();
+
+  try {
+    const response = await axios.get(
+      `${process.env.REACT_APP_SERVER_URL}/auth/refresh`
+    );
+
+    return response;
+  } catch (err) {
+    if (err.responce.status === 403) {
+      try {
+        await axios.post(`${process.env.REACT_APP_SERVER_URL}/auth/logout`, {
+          email,
+        });
+
+        GoogleAuth.signOut().then(function () {
+          GoogleAuth.disconnect();
+        });
+
+        navigate("/login");
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  }
+}
+
+export default verifyRefreshToken;

--- a/src/api/refreshToken.js
+++ b/src/api/refreshToken.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import useGapi from "../hooks/useGapi";
+import getAccessToken from "../utils/accessToken";
 
 async function verifyRefreshToken(email) {
   const navigate = useNavigate();
@@ -8,11 +9,7 @@ async function verifyRefreshToken(email) {
   const GoogleAuth = gapi.auth2.getAuthInstance();
 
   try {
-    const response = await axios.get(
-      `${process.env.REACT_APP_SERVER_URL}/auth/refresh`
-    );
-
-    return response;
+    return await getAccessToken();
   } catch (err) {
     if (err.responce.status === 403) {
       try {

--- a/src/components/Town/Town.js
+++ b/src/components/Town/Town.js
@@ -1,10 +1,6 @@
-import React, { useEffect } from "react";
-import getAccessToken from "../../utils/accessToken";
+import React from "react";
 
 function Town() {
-  useEffect(() => {
-    getAccessToken();
-  });
   return <div>이것은 마을 페이지</div>;
 }
 

--- a/src/components/Town/Town.js
+++ b/src/components/Town/Town.js
@@ -1,6 +1,10 @@
-import React from "react";
+import React, { useEffect } from "react";
+import getAccessToken from "../../utils/accessToken";
 
 function Town() {
+  useEffect(() => {
+    getAccessToken();
+  });
   return <div>이것은 마을 페이지</div>;
 }
 

--- a/src/utils/accessToken.js
+++ b/src/utils/accessToken.js
@@ -2,7 +2,8 @@ import axios from "axios";
 
 async function getAccessToken() {
   const response = await axios.get(
-    `${process.env.REACT_APP_BASE_URL}/auth/refresh`
+    `${process.env.REACT_APP_BASE_URL}/auth/refresh`,
+    { withCredentials: true }
   );
 
   return response.data;

--- a/src/utils/accessToken.js
+++ b/src/utils/accessToken.js
@@ -1,0 +1,11 @@
+import axios from "axios";
+
+async function getAccessToken() {
+  const response = await axios.get(
+    `${process.env.REACT_APP_BASE_URL}/auth/refresh`
+  );
+
+  return response.data;
+}
+
+export default getAccessToken;


### PR DESCRIPTION
# feature: login persist

## 노션 칸반 링크
​
- [login persist(accessToken, refreshToken expire handle)](https://www.notion.so/vanillacoding/a595c93791e440d78feaa34f9ba6b81b?v=b466274725384ef899a2bc8f94b4b4fa&p=f203510585d94130ad6f35e9b63a9bc1)
​
## 카드에서 구현 혹은 해결하려는 내용

- 로그인 상태를 관리하는 refreshToken이 만료된 경우에 서버에서 403에러가 반환되는데 이 경우 로그인 되어있는 GoogleUser를 SignOut 시킨 후 로그인 창으로 이동시킵니다.
- 프론트에서 서버로 요청을 보낼 경우 axios 마다 동일한 헤더값 처리를 해주기 위해 interceptor를 사용 했습니다.
- 로그인 되어있는 유저의 메일 정보를 가져오기 위한 accessToken이 만료된 경우 서버 통신시에 401에러가 반환되는데 이 경우 axios의 interceptor를 사용하여 요청이 처리되기 전에 가로채 accessToken을 재발급 시켜줄수 있도록 구현했습니다.
- 로그인 컴포넌트 렌더 시 현재 로그인 되어있는 유저가 있는지 확인한 후 유저 정보를 제공 해주는 로직을 작성 했습니다. 
- /auth/refresh GET 요청 사용이 잦아 util 함수로 만들었습니다.
​
## 기타 사항
- auth.js 의 경우 로그인 되어 있는 유저의 정보를 반환만 해주고 있기 때문에 비동기로 함수 호출 뒤 반환값을 전역 상태에 저장시켜 주어야 합니다.