### PR TITLE
Feature/user/items/inbox/myitem

### DIFF
--- a/src/api/item.js
+++ b/src/api/item.js
@@ -24,6 +24,31 @@ export async function getPresentBox(townId) {
   }
 }
 
+export async function changeStorage(userId, itemId, from, to) {
+  try {
+    const response = await axios.put(
+      `${process.env.REACT_APP_SERVER_URL}/users/${userId}/items/${itemId}`,
+      { from, to }
+    );
+
+    return response.data;
+  } catch (err) {
+    console.error(err);
+  }
+}
+export async function addItem(userId, name, price) {
+  try {
+    const response = await axios.post(
+      `${process.env.REACT_APP_SERVER_URL}/users/${userId}/items/present`,
+      { name, price }
+    );
+
+    return response.data;
+  } catch (err) {
+    console.error(err);
+  }
+}
+
 export async function sendItem(townId, presentTo, name, price) {
   try {
     const response = await axios.post(

--- a/src/components/Header/header.js
+++ b/src/components/Header/header.js
@@ -79,7 +79,7 @@ function Header({ toggleMail, toggleFindUser, toggleFriendList, toggleShop }) {
               toggleFriendList(true);
             }}
           />
-          <i className="fas fa-store" />
+          <i className="fas fa-store" onClick={toggleShop} />
           <i className="fas fa-sign-out-alt" onClick={logout} />
         </StyledNavWrapperNav>
       )}

--- a/src/components/Item/Item.js
+++ b/src/components/Item/Item.js
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 
-const StyledItemOverlayDiv = styled.div`
+const ItemOverlayDiv = styled.div`
   display: ${(props) => props.display};
   position: absolute;
   z-index: 999;
@@ -18,7 +18,7 @@ const StyledItemOverlayDiv = styled.div`
   }
 `;
 
-const StyledItemContainerDiv = styled.div`
+const ItemContainerDiv = styled.div`
   width: 49%;
   height: 220px;
   border: 10px solid #133a4d;
@@ -80,7 +80,7 @@ const StyledItemContainerDiv = styled.div`
   }
 `;
 
-const StyledCashContainerDiv = styled.div`
+const CashContainerDiv = styled.div`
   display: flex;
   justify-content: center;
   justify-content: space-between;
@@ -111,7 +111,7 @@ function Item({
   moveToOutBox,
 }) {
   return (
-    <StyledItemContainerDiv
+    <ItemContainerDiv
       onClick={(e) => {
         {
           toggleNotification && toggleNotification(true);
@@ -121,14 +121,14 @@ function Item({
         }
       }}
     >
-      <StyledItemOverlayDiv display={shouldOverlaid ? "block" : "none"}>
+      <ItemOverlayDiv display={shouldOverlaid ? "block" : "none"}>
         <i className="fas fa-solid fa-lock lock" />
-      </StyledItemOverlayDiv>
+      </ItemOverlayDiv>
       <img src={`/images/${imageName}.png`} id={imageName} />
       {storageType === "myItemBox" && <p>{`x ${content}`}</p>}
       {storageType === "presentBox" && <p>{`From ${content}`}</p>}
       {storageType === "shop" && (
-        <StyledCashContainerDiv>
+        <CashContainerDiv>
           <>
             <img src="/images/coke.png" />
             <p>{content}</p>
@@ -136,9 +136,9 @@ function Item({
           <button>
             <i className="fas fa-solid fa-gift" />
           </button>
-        </StyledCashContainerDiv>
+        </CashContainerDiv>
       )}
-    </StyledItemContainerDiv>
+    </ItemContainerDiv>
   );
 }
 

--- a/src/components/Item/Item.js
+++ b/src/components/Item/Item.js
@@ -102,9 +102,25 @@ const StyledCashContainerDiv = styled.div`
   }
 `;
 
-function Item({ storageType, content, imageName, shouldOverlaid }) {
+function Item({
+  storageType,
+  content,
+  imageName,
+  shouldOverlaid,
+  toggleNotification,
+  moveToOutBox,
+}) {
   return (
-    <StyledItemContainerDiv>
+    <StyledItemContainerDiv
+      onClick={(e) => {
+        {
+          toggleNotification && toggleNotification(true);
+        }
+        {
+          moveToOutBox && moveToOutBox(e.target.id);
+        }
+      }}
+    >
       <StyledItemOverlayDiv display={shouldOverlaid ? "block" : "none"}>
         <i className="fas fa-solid fa-lock lock" />
       </StyledItemOverlayDiv>
@@ -137,4 +153,6 @@ Item.propTypes = {
   ]),
   imageName: PropTypes.string.isRequired,
   shouldOverlaid: PropTypes.bool,
+  toggleNotification: PropTypes.func,
+  moveToOutBox: PropTypes.func,
 };

--- a/src/components/ItemBox/ItemBox.js
+++ b/src/components/ItemBox/ItemBox.js
@@ -10,7 +10,7 @@ function ItemBox({ toggleItemBox }) {
     <GameModal onClose={toggleItemBox}>
       <HalfModal category={["내 아이템", "선물함"]}>
         <MyItemBox onClose={toggleItemBox} />
-        <PresentBox />
+        <PresentBox onClose={toggleItemBox} />
       </HalfModal>
     </GameModal>
   );

--- a/src/components/ItemBox/ItemBox.js
+++ b/src/components/ItemBox/ItemBox.js
@@ -5,11 +5,11 @@ import HalfModal from "../GameModal/HalfModal";
 import PresentBox from "./PresentBox";
 import MyItemBox from "./MyItemBox";
 
-function ItemBox({ onClose }) {
+function ItemBox({ toggleItemBox }) {
   return (
-    <GameModal onClose={onClose}>
+    <GameModal onClose={toggleItemBox}>
       <HalfModal category={["내 아이템", "선물함"]}>
-        <MyItemBox onClose={onClose} />
+        <MyItemBox onClose={toggleItemBox} />
         <PresentBox />
       </HalfModal>
     </GameModal>
@@ -19,5 +19,5 @@ function ItemBox({ onClose }) {
 export default ItemBox;
 
 ItemBox.propTypes = {
-  onClose: PropTypes.func.isRequired,
+  toggleItemBox: PropTypes.func.isRequired,
 };

--- a/src/components/ItemBox/ItemBox.js
+++ b/src/components/ItemBox/ItemBox.js
@@ -9,7 +9,7 @@ function ItemBox({ onClose }) {
   return (
     <GameModal onClose={onClose}>
       <HalfModal category={["내 아이템", "선물함"]}>
-        <MyItemBox />
+        <MyItemBox onClose={onClose} />
         <PresentBox />
       </HalfModal>
     </GameModal>

--- a/src/components/ItemBox/MyItemBox.js
+++ b/src/components/ItemBox/MyItemBox.js
@@ -2,8 +2,9 @@ import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { useParams } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
+import PropTypes from "prop-types";
 import Item from "../Item/Item";
-import { getInItemBox } from "../../api/item";
+import { changeStorage, getInItemBox } from "../../api/item";
 import { countItem, itemCounter } from "../../utils/item";
 import { ITEM_LIST } from "../../constants/item";
 import {
@@ -18,7 +19,7 @@ const StyledDiv = styled.div`
   justify-content: space-between;
 `;
 
-function MyItemBox() {
+function MyItemBox({ onClose }) {
   const dispatch = useDispatch();
   const { id } = useParams();
   const [isMounted, setIsMounted] = useState(false);
@@ -58,6 +59,16 @@ function MyItemBox() {
     countItem(null, true);
   }, [myItemList]);
 
+  const moveItemToOutBox = async (itemName) => {
+    const targetItem = myItemList.find((item) => {
+      return item.name === itemName;
+    });
+
+    await changeStorage(id, targetItem._id, "inItemBox", "outItemBox");
+
+    onClose(false);
+  };
+
   return (
     <StyledDiv>
       {ITEM_LIST.map((item) => {
@@ -68,6 +79,7 @@ function MyItemBox() {
             content={item === "Ice" ? iceCount : itemCount[item]}
             imageName={item}
             shouldOverlaid={itemCount[item] === 0 ? true : false}
+            moveToOutBox={moveItemToOutBox}
           />
         );
       })}
@@ -76,3 +88,7 @@ function MyItemBox() {
 }
 
 export default MyItemBox;
+
+MyItemBox.propTypes = {
+  onClose: PropTypes.func.isRequired,
+};

--- a/src/components/ItemBox/MyItemBox.js
+++ b/src/components/ItemBox/MyItemBox.js
@@ -12,7 +12,7 @@ import {
   updateItemCount,
 } from "../../features/user/userSlice";
 
-const StyledDiv = styled.div`
+const ItemContainerDiv = styled.div`
   display: flex;
   width: 450px;
   flex-wrap: wrap;
@@ -70,7 +70,7 @@ function MyItemBox({ onClose }) {
   };
 
   return (
-    <StyledDiv>
+    <ItemContainerDiv>
       {ITEM_LIST.map((item) => {
         return (
           <Item
@@ -83,7 +83,7 @@ function MyItemBox({ onClose }) {
           />
         );
       })}
-    </StyledDiv>
+    </ItemContainerDiv>
   );
 }
 

--- a/src/components/ItemBox/PresentBox.js
+++ b/src/components/ItemBox/PresentBox.js
@@ -2,7 +2,8 @@ import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
 import { nanoid } from "nanoid";
-import { getPresentBox } from "../../api/item";
+import PropTypes from "prop-types";
+import { changeStorage, getPresentBox } from "../../api/item";
 import Item from "../Item/Item";
 
 const ItemContainerDiv = styled.div`
@@ -20,7 +21,7 @@ const ItemContainerDiv = styled.div`
   }
 `;
 
-function PresentBox() {
+function PresentBox({ onClose }) {
   const [presentList, setPresentList] = useState([]);
   const { id } = useParams();
   const GMAIL_ADDRESS = 10;
@@ -34,6 +35,16 @@ function PresentBox() {
       console.error(err);
     }
   }, []);
+
+  const moveItemToOutBox = async (itemName) => {
+    const targetItem = presentList.find((item) => {
+      return item.name === itemName;
+    });
+
+    await changeStorage(id, targetItem._id, "presentBox", "outItemBox");
+
+    onClose(false);
+  };
 
   return (
     <ItemContainerDiv>
@@ -49,6 +60,7 @@ function PresentBox() {
                 item.purchasedBy.length - GMAIL_ADDRESS
               )}
               imageName={item.name}
+              moveToOutBox={moveItemToOutBox}
             />
           );
         })}
@@ -57,3 +69,7 @@ function PresentBox() {
 }
 
 export default PresentBox;
+
+PresentBox.propTypes = {
+  onClose: PropTypes.func.isRequired,
+};

--- a/src/components/ItemBox/PresentBox.js
+++ b/src/components/ItemBox/PresentBox.js
@@ -5,7 +5,7 @@ import { nanoid } from "nanoid";
 import { getPresentBox } from "../../api/item";
 import Item from "../Item/Item";
 
-const StyledItemContainerDiv = styled.div`
+const ItemContainerDiv = styled.div`
   display: flex;
   position: relative;
   width: 450px;
@@ -36,7 +36,7 @@ function PresentBox() {
   }, []);
 
   return (
-    <StyledItemContainerDiv>
+    <ItemContainerDiv>
       {presentList &&
         presentList.map((item) => {
           const key = nanoid();
@@ -52,7 +52,7 @@ function PresentBox() {
             />
           );
         })}
-    </StyledItemContainerDiv>
+    </ItemContainerDiv>
   );
 }
 

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -2,10 +2,6 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 import GameModal from "../GameModal/GameModal";
-import {
-  selectNotificationType,
-  closeNotification,
-} from "../../features/modal/modalSlice";
 import GameModalButton from "../GameModal/GameModalButton";
 import { nanoid } from "nanoid";
 import { TYPE, MESSAGE, OPTION } from "../../constants/notification";
@@ -33,7 +29,6 @@ const ButtonContainer = styled.div`
 `;
 
 function Notification({ toggleNotification }) {
-  const dispatch = useDispatch();
   const notificationType = useSelector(selectNotificationType);
   const [buttonContent, setButtonContent] = useState([]);
   const [notificationMessage, setNotificationMessage] = useState("");
@@ -55,7 +50,7 @@ function Notification({ toggleNotification }) {
     <GameModal
       subject={notificationType === "friendRequest" && "친구 요청"}
       onClose={() => {
-        dispatch(closeNotification());
+        toggleNotification();
       }}
     >
       <NotificationContainer>

--- a/src/components/Shop/Shop.js
+++ b/src/components/Shop/Shop.js
@@ -12,7 +12,7 @@ const StyledDiv = styled.div`
   justify-content: space-between;
 `;
 
-function Shop({ onClose }) {
+function Shop({ onClose, toggleNotification }) {
   return (
     <GameModal onClose={onClose} subject="상점">
       <StyledDiv>
@@ -23,6 +23,7 @@ function Shop({ onClose }) {
               storageType="shop"
               content={ITEM_PRICE_LIST[item]}
               imageName={item}
+              toggleNotification={toggleNotification}
             />
           );
         })}
@@ -35,4 +36,5 @@ export default Shop;
 
 Shop.propTypes = {
   onClose: PropTypes.func.isRequired,
+  toggleNotification: PropTypes.func,
 };

--- a/src/components/Town/PostBox.js
+++ b/src/components/Town/PostBox.js
@@ -1,8 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { useDispatch } from "react-redux";
 import proptype from "prop-types";
-import { openGuestBook } from "../../features/modal/modalSlice";
 
 const PostBoxContainer = styled.div`
   width: 100vw;

--- a/src/components/Town/Town.js
+++ b/src/components/Town/Town.js
@@ -24,8 +24,8 @@ function Town({ onTownTransition }) {
   const [onPostBox, setOnPostBox] = useState(false);
   const [onNotification, setOnNotification] = useState(false);
   const [onFriendList, setOnFriendList] = useState(false);
-  const [isItemBoxOpen, setIsItemBoxOpen] = useState(false);
-  const [isShopOpen, setIsShopOpen] = useState(false);
+  const [onItemBox, setOnItemBox] = useState(false);
+  const [onShop, setOnShop] = useState(false);
 
   return (
     <>
@@ -33,7 +33,7 @@ function Town({ onTownTransition }) {
         toggleMail={setOnMail}
         toggleFindUser={() => {}}
         toggleFriendList={setOnFriendList}
-        toggleShop={() => {}}
+        toggleShop={setOnShop}
       />
       <CokeCounter />
       <StyledTownDiv>
@@ -50,8 +50,8 @@ function Town({ onTownTransition }) {
               toggleFriendList={setOnFriendList}
             />
           )}
-          {isItemBoxOpen && <ItemBox onClose={setIsItemBoxOpen} />}
-          {isShopOpen && <Shop onClose={setIsShopOpen} />}
+          {onItemBox && <ItemBox onClose={setOnItemBox} />}
+          {onShop && <Shop onClose={setOnShop} />}
         </ModalPortals>
       </StyledTownDiv>
     </>

--- a/src/components/Town/Town.js
+++ b/src/components/Town/Town.js
@@ -24,7 +24,7 @@ function Town({ onTownTransition }) {
   const [onPostBox, setOnPostBox] = useState(false);
   const [onNotification, setOnNotification] = useState(false);
   const [onFriendList, setOnFriendList] = useState(false);
-  const [onItemBox, setOnItemBox] = useState(false);
+  const [onItemBox, setOnItemBox] = useState(true);
   const [onShop, setOnShop] = useState(false);
 
   return (
@@ -51,7 +51,9 @@ function Town({ onTownTransition }) {
             />
           )}
           {onItemBox && <ItemBox onClose={setOnItemBox} />}
-          {onShop && <Shop onClose={setOnShop} />}
+          {onShop && (
+            <Shop onClose={setOnShop} toggleNotification={setOnNotification} />
+          )}
         </ModalPortals>
       </StyledTownDiv>
     </>

--- a/src/components/Town/Town.js
+++ b/src/components/Town/Town.js
@@ -50,7 +50,7 @@ function Town({ onTownTransition }) {
               toggleFriendList={setOnFriendList}
             />
           )}
-          {onItemBox && <ItemBox onClose={setOnItemBox} />}
+          {onItemBox && <ItemBox toggleItemBox={setOnItemBox} />}
           {onShop && (
             <Shop onClose={setOnShop} toggleNotification={setOnNotification} />
           )}


### PR DESCRIPTION
# Feature/user/items/inbox/myitem
​
## 카드에서 구현 혹은 해결하려는 내용
- 내 아이템함에서 유저가 보유하고 있는 아이템을 클릭할 경우 해당 아이템은 inbox -> outbox로 이동하게 됩니다.
- 클릭했을때 아이템함은 닫히게 되고 클릭된 아이템은 화면의 중앙에 띄워집니다.
​
## UI
-펭귄 아이템이 2개 존재
![스크린샷 2022-02-11 오후 6 22 44](https://user-images.githubusercontent.com/81972688/153566488-826811db-cba8-44ec-a181-ddc37747a6fc.png)

-펭귄을 클릭 한 뒤 내 아이템 함의 펭귄 개수가 1개 줄음
![스크린샷 2022-02-11 오후 6 20 25](https://user-images.githubusercontent.com/81972688/153566510-d246dc4e-919e-4a03-a3cd-cf13def758d8.png)

## 기타 사항
- 현재 아이템을 클릭 했을때 아이템은 inbox에서 outbox로 이동하지만 화면에 아이템들을 띄워주지 않고 있어 화면에는 변화가 없습니다.
- 얼음 업그레이드 지수를 알려주는 iceCount를 불러오는 api가 수정되어서 머지후 충돌이 날 수 있습니다.  - 로그인 되었을때 iceCount를 서버에서 받아와 전역 상태에 저장