### PR TITLE
socket: socket client connection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1984,6 +1984,16 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@socket.io/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-dOlCBKnDw4iShaIsH/bxujKTM18+2TOAsYz+KSc11Am38H4q5Xw8Bbz97ZYdrVNM+um3p7w86Bvvmcn9q+5+eQ=="
+    },
+    "@socket.io/component-emitter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
+      "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q=="
+    },
     "@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -3607,6 +3617,11 @@
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
       }
     },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4844,6 +4859,37 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "engine.io-client": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.1.1.tgz",
+      "integrity": "sha512-V05mmDo4gjimYW+FGujoGmmmxRaDsrVr7AXA3ZIfa04MWM1jOfZfUwou0oNqhNwy/votUDvGDt4JA4QF4e0b4g==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.0.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.0",
+        "has-cors": "1.1.0",
+        "parseqs": "0.0.6",
+        "parseuri": "0.0.6",
+        "ws": "~8.2.3",
+        "xmlhttprequest-ssl": "~2.0.0",
+        "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA=="
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.3.tgz",
+      "integrity": "sha512-BtQxwF27XUNnSafQLvDi0dQ8s3i6VgzSoQMJacpIcGNrlUdfHSKbgm3jmjCVvQluGzqwujQMPAoMai3oYSTurg==",
+      "requires": {
+        "@socket.io/base64-arraybuffer": "~1.0.2"
+      }
+    },
     "enhanced-resolve": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
@@ -6021,6 +6067,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
       "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+    },
+    "has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
     },
     "has-flag": {
       "version": "3.0.0",
@@ -8794,6 +8845,16 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
+    "parseqs": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+      "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
+    },
+    "parseuri": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+      "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -10684,6 +10745,28 @@
         }
       }
     },
+    "socket.io-client": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.4.1.tgz",
+      "integrity": "sha512-N5C/L5fLNha5Ojd7Yeb/puKcPWWcoB/A09fEjjNsg91EDVr5twk/OEyO6VT9dlLSUNY85NpW6KBhVMvaLKQ3vQ==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.0.0",
+        "backo2": "~1.0.2",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.1.1",
+        "parseuri": "0.0.6",
+        "socket.io-parser": "~4.1.1"
+      }
+    },
+    "socket.io-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.1.tgz",
+      "integrity": "sha512-USQVLSkDWE5nbcY760ExdKaJxCE65kcsG/8k5FDGZVVxpD1pA7hABYXYkCUvxUuYYh/+uQw0N/fvBzfT8o07KA==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.0.0",
+        "debug": "~4.3.1"
+      }
+    },
     "sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -12169,6 +12252,11 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
+    "xmlhttprequest-ssl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A=="
+    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -12207,6 +12295,11 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-redux": "^7.2.6",
     "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",
+    "socket.io-client": "^4.4.1",
     "styled-components": "^5.3.3"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from "react";
 import { Route, Routes, useNavigate } from "react-router-dom";
+import proptyoes from "prop-types";
 import GlobalStyle from "./GlobalStyle";
 import Login from "./components/Login/Login";
 import Town from "./components/Town/Town";
 
-function App() {
+function App({ socketService }) {
   const [townId, setTownId] = useState("");
   const navigate = useNavigate();
 
@@ -18,12 +19,22 @@ function App() {
       <Routes>
         <Route
           path="/users/:id"
-          element={<Town onTownTransition={setTownId} />}
+          element={
+            <Town
+              townId={townId}
+              onTownTransition={setTownId}
+              socketService={socketService}
+            />
+          }
         />
         <Route path="/login" element={<Login goTown={setTownId} />} />
       </Routes>
     </>
   );
 }
+
+App.propTypes = {
+  socketService: proptyoes.object,
+};
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,27 @@
 import React, { useEffect, useState } from "react";
 import { Route, Routes, useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
 import proptyoes from "prop-types";
 import GlobalStyle from "./GlobalStyle";
 import Login from "./components/Login/Login";
 import Town from "./components/Town/Town";
+import { setSocket } from "./features/user/userSlice";
 
 function App({ socketService }) {
   const [townId, setTownId] = useState("");
+  const dispatch = useDispatch();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    console.log(process.env.REACT_APP_BASE_URL);
+
+    const connection = socketService.connect(process.env.REACT_APP_BASE_URL);
+    dispatch(setSocket(connection));
+
+    return () => {
+      socketService.disconnect(connection);
+    };
+  }, []);
 
   useEffect(() => {
     townId ? navigate(`users/${townId}`) : navigate("/login");
@@ -19,13 +33,7 @@ function App({ socketService }) {
       <Routes>
         <Route
           path="/users/:id"
-          element={
-            <Town
-              townId={townId}
-              onTownTransition={setTownId}
-              socketService={socketService}
-            />
-          }
+          element={<Town townId={townId} onTownTransition={setTownId} />}
         />
         <Route path="/login" element={<Login goTown={setTownId} />} />
       </Routes>

--- a/src/api/socket.js
+++ b/src/api/socket.js
@@ -1,0 +1,11 @@
+import { io } from "socket.io-client";
+
+export default class SocketService {
+  connect(baseUrl) {
+    return io(baseUrl);
+  }
+
+  disconnect(connection) {
+    connection.disconnect();
+  }
+}

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -2,10 +2,6 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 import GameModal from "../GameModal/GameModal";
-import {
-  selectNotificationType,
-  closeNotification,
-} from "../../features/modal/modalSlice";
 import GameModalButton from "../GameModal/GameModalButton";
 import { nanoid } from "nanoid";
 import { TYPE, MESSAGE, OPTION } from "../../constants/notification";

--- a/src/components/Town/PostBox.js
+++ b/src/components/Town/PostBox.js
@@ -1,8 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { useDispatch } from "react-redux";
 import proptype from "prop-types";
-import { openGuestBook } from "../../features/modal/modalSlice";
 
 const PostBoxContainer = styled.div`
   width: 100vw;

--- a/src/components/Town/Town.js
+++ b/src/components/Town/Town.js
@@ -19,27 +19,13 @@ const StyledTownDiv = styled.div`
   background-position: center 90%;
 `;
 
-function Town({ townId, onTownTransition, socketService }) {
+function Town({ onTownTransition }) {
   const [onMail, setOnMail] = useState(false);
   const [onPostBox, setOnPostBox] = useState(false);
   const [onNotification, setOnNotification] = useState(false);
   const [onFriendList, setOnFriendList] = useState(false);
   const [isItemBoxOpen, setIsItemBoxOpen] = useState(false);
   const [isShopOpen, setIsShopOpen] = useState(false);
-  const [socket, setSocket] = useState(null);
-
-  useEffect(() => {
-    if (!townId) return;
-
-    console.log(process.env.REACT_APP_BASE_URL);
-
-    const connection = socketService.connect(process.env.REACT_APP_BASE_URL);
-    setSocket(connection);
-
-    return () => {
-      socketService.disconnect(connection);
-    };
-  }, [townId]);
 
   return (
     <>
@@ -75,7 +61,7 @@ function Town({ townId, onTownTransition, socketService }) {
 Town.propTypes = {
   townId: proptypes.string.isRequired,
   onTownTransition: proptypes.func.isRequired,
-  socketService: proptypes.object,
+  socket: proptypes.object,
 };
 
 export default Town;

--- a/src/components/Town/Town.js
+++ b/src/components/Town/Town.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import proptypes from "prop-types";
 import styled from "styled-components";
 import PostBox from "./PostBox";
@@ -19,13 +19,27 @@ const StyledTownDiv = styled.div`
   background-position: center 90%;
 `;
 
-function Town({ onTownTransition }) {
+function Town({ townId, onTownTransition, socketService }) {
   const [onMail, setOnMail] = useState(false);
   const [onPostBox, setOnPostBox] = useState(false);
   const [onNotification, setOnNotification] = useState(false);
   const [onFriendList, setOnFriendList] = useState(false);
   const [isItemBoxOpen, setIsItemBoxOpen] = useState(false);
   const [isShopOpen, setIsShopOpen] = useState(false);
+  const [socket, setSocket] = useState(null);
+
+  useEffect(() => {
+    if (!townId) return;
+
+    console.log(process.env.REACT_APP_BASE_URL);
+
+    const connection = socketService.connect(process.env.REACT_APP_BASE_URL);
+    setSocket(connection);
+
+    return () => {
+      socketService.disconnect(connection);
+    };
+  }, [townId]);
 
   return (
     <>
@@ -59,7 +73,9 @@ function Town({ onTownTransition }) {
 }
 
 Town.propTypes = {
+  townId: proptypes.string.isRequired,
   onTownTransition: proptypes.func.isRequired,
+  socketService: proptypes.object,
 };
 
 export default Town;

--- a/src/features/user/userSlice.js
+++ b/src/features/user/userSlice.js
@@ -14,6 +14,7 @@ const initialState = {
     Igloo: 0,
     Flower: 0,
   },
+  socket: null,
 };
 
 export const userSlice = createSlice({
@@ -25,7 +26,7 @@ export const userSlice = createSlice({
         action.payload;
 
       return {
-        ...initialState,
+        ...state,
         id,
         username,
         email,
@@ -58,6 +59,9 @@ export const userSlice = createSlice({
         itemCount: { PolarBear, Penguin, Seal, Igloo, Flower },
       };
     },
+    setSocket: (state, action) => {
+      state.socket = action.payload;
+    },
   },
 });
 
@@ -68,6 +72,7 @@ export const {
   increseCoke,
   decreaseCoke,
   updateItemCount,
+  setSocket,
 } = userSlice.actions;
 
 export const selectUser = (state) => state.user;

--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,15 @@ import App from "./App";
 import { store } from "./app/store";
 import { Provider } from "react-redux";
 import * as serviceWorker from "./serviceWorker";
+import SocketService from "./api/socket";
+
+const socketService = new SocketService();
 
 ReactDOM.render(
   <React.StrictMode>
     <BrowserRouter>
       <Provider store={store}>
-        <App />
+        <App socketService={socketService} />
       </Provider>
     </BrowserRouter>
   </React.StrictMode>,


### PR DESCRIPTION
# feature : socket connection

## 노션 칸반 링크
​
- [[Frontend] Client Socket 셋팅](https://www.notion.so/vanillacoding/a595c93791e440d78feaa34f9ba6b81b?v=b466274725384ef899a2bc8f94b4b4fa&p=c0e9d7da6c0d4a95a0408964c5ba8373)
​
## 카드에서 구현 혹은 해결하려는 내용
- 서버와 소켓 연결하기
​
## 테스트 방법
- 실시간 이벤트가 모두 타운 페이지에서 일어나므로, 타운 페이지 렌더시 useEffect로 소켓 연결, 백엔드에서 client 접속 확인되는지 확인하였습니다. 

## 기타 사항
- socket 관련한 이벤트들을 하나하나 불러오기 보다는 클래스 안에 담아서 그 객체를 프롭으로 내려주고 필요한 곳에서 메서드를 사용할 수 있게 코드를 짜봤습니다. 다른 api 폴더 속 코드와 스타일이 다르기 때문에 이 부분 어떻게 생각하시는지 궁금합니다!