### PR TITLE
feature : show realtime guestbook upate

### DIFF
--- a/src/api/item.js
+++ b/src/api/item.js
@@ -3,7 +3,7 @@ import axios from "axios";
 export async function getInItemBox(townId) {
   try {
     const response = await axios.get(
-      `${process.env.REACT_APP_SERVER_URL}/users/${townId}/items`,
+      `${process.env.REACT_APP_BASE_URL}/users/${townId}/items`,
     );
 
     return response.data;
@@ -15,7 +15,7 @@ export async function getInItemBox(townId) {
 export async function getPresentBox(townId) {
   try {
     const response = await axios.get(
-      `${process.env.REACT_APP_SERVER_URL}/users/${townId}/items/present`,
+      `${process.env.REACT_APP_BASE_URL}/users/${townId}/items/present`,
     );
 
     return response.data;
@@ -27,7 +27,7 @@ export async function getPresentBox(townId) {
 export async function changeStorage(userId, itemId, from, to) {
   try {
     const response = await axios.put(
-      `${process.env.REACT_APP_SERVER_URL}/users/${userId}/items/${itemId}`,
+      `${process.env.REACT_APP_BASE_URL}/users/${userId}/items/${itemId}`,
       { from, to },
     );
 
@@ -40,7 +40,7 @@ export async function changeStorage(userId, itemId, from, to) {
 export async function addItem(userId, name, price) {
   try {
     const response = await axios.post(
-      `${process.env.REACT_APP_SERVER_URL}/users/${userId}/items`,
+      `${process.env.REACT_APP_BASE_URL}/users/${userId}/items`,
       { name, price },
     );
 
@@ -53,7 +53,7 @@ export async function addItem(userId, name, price) {
 export async function sendItem(townId, presentTo, name, price) {
   try {
     const response = await axios.post(
-      `${process.env.REACT_APP_SERVER_URL}/users/${townId}/items/present`,
+      `${process.env.REACT_APP_BASE_URL}/users/${townId}/items/present`,
       { presentTo, name, price },
     );
 

--- a/src/api/mail.js
+++ b/src/api/mail.js
@@ -4,7 +4,7 @@ import axios from "axios";
 export async function getMailList(at, userId, inboxId, pageToken = null) {
   try {
     const response = await axios.get(
-      `${process.env.REACT_APP_SERVER_URL}/users/${userId}/mails/${inboxId}/${pageToken}`,
+      `${process.env.REACT_APP_BASE_URL}/users/${userId}/mails/${inboxId}/${pageToken}`,
       {
         headers: {
           gapiauthorization: `Bearer ${at}`,
@@ -22,7 +22,7 @@ export async function getMailList(at, userId, inboxId, pageToken = null) {
 export async function moveEmailToTrash(at, userId, mailId) {
   try {
     const response = await axios.post(
-      `${process.env.REACT_APP_SERVER_URL}/users/${userId}/mails/trash`,
+      `${process.env.REACT_APP_BASE_URL}/users/${userId}/mails/trash`,
       {
         mailId,
       },
@@ -43,7 +43,7 @@ export async function moveEmailToTrash(at, userId, mailId) {
 export async function deleteTrashEmail(at, userId, mailId, count) {
   try {
     const response = await axios.delete(
-      `${process.env.REACT_APP_SERVER_URL}/users/${userId}/mails/trash`,
+      `${process.env.REACT_APP_BASE_URL}/users/${userId}/mails/trash`,
       {
         headers: {
           gapiauthorization: `Bearer ${at}`,

--- a/src/api/refreshToken.js
+++ b/src/api/refreshToken.js
@@ -13,7 +13,7 @@ async function verifyRefreshToken(email) {
   } catch (err) {
     if (err.response.status === 403) {
       try {
-        await axios.post(`${process.env.REACT_APP_SERVER_URL}/auth/logout`, {
+        await axios.post(`${process.env.REACT_APP_BASE_URL}/auth/logout`, {
           email,
         });
 

--- a/src/components/GuestBook/MessageInput.js
+++ b/src/components/GuestBook/MessageInput.js
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import styled from "styled-components";
 import proptypes from "prop-types";
 import { leaveNewMessage } from "../../api/guestbook";
+import { EVENTS } from "../../constants/socketEvents";
 
 const StyledInputContainer = styled.div`
   display: flex;
@@ -27,15 +28,20 @@ const StyledInputContainer = styled.div`
   }
 `;
 
-function MessageInput({ onMessageListUpdate }) {
+function MessageInput({ onMessageListUpdate, socket }) {
   const { id } = useParams();
   const messageInput = useRef();
 
   async function handleSendButtonClick() {
     const messageValue = messageInput.current.value;
-    const { newMessage } = await leaveNewMessage(id, messageValue);
 
-    onMessageListUpdate((prev) => [newMessage, ...prev]);
+    try {
+      const { newMessage } = await leaveNewMessage(id, messageValue);
+      socket.emit(EVENTS.SEND_MESSAGE, { townId: id, message: newMessage });
+      messageInput.current.value = "";
+    } catch (error) {
+      console.error(error);
+    }
   }
 
   return (
@@ -48,6 +54,7 @@ function MessageInput({ onMessageListUpdate }) {
 
 MessageInput.propTypes = {
   onMessageListUpdate: proptypes.func.isRequired,
+  socket: proptypes.object,
 };
 
 export default MessageInput;

--- a/src/components/Town/OutItem.js
+++ b/src/components/Town/OutItem.js
@@ -19,7 +19,6 @@ function OutItem({ name, isMe, itemId, setOutItems }) {
   const goToOutBox = async () => {
     const response = await changeStorage(id, itemId, "outItemBox", "inItemBox");
     const { outBox } = response.result;
-
     setOutItems(outBox);
   };
 

--- a/src/components/Town/Town.js
+++ b/src/components/Town/Town.js
@@ -81,7 +81,6 @@ function Town({ iceCount, onTownTransition }) {
     socket.on(EVENTS.LEFT, (data) => {
       setVisitors(data.visitors);
     });
-
     return () => {
       socket.off(EVENTS.JOIN);
       socket.off(EVENTS.LEFT);
@@ -124,11 +123,17 @@ function Town({ iceCount, onTownTransition }) {
             setOutItems={setOutItems}
           />
         ))}
-        <PostBox toggleGuestbook={setOnPostBox} />
+        <PostBox toggleGuestbook={setOnPostBox} socket={getSocketIO()} />
         {isMe && <InItemBox toggleItemBox={setOnItemBoxOpen} />}
         <ModalPortals>
           {onMail && <Mail toggleMail={setOnMail} />}
-          {onPostBox && <GuestBook toggleGuestbook={setOnPostBox} />}
+          {onPostBox && (
+            <GuestBook
+              isOpen={onPostBox}
+              toggleGuestbook={setOnPostBox}
+              socket={getSocketIO()}
+            />
+          )}
           {onShopOpen && (
             <Shop
               onClose={setOnShopOpen}

--- a/src/constants/socketEvents.js
+++ b/src/constants/socketEvents.js
@@ -1,6 +1,7 @@
 export const EVENTS = {
   JOIN: "join",
   LEFT: "left",
+  READ_MESSAGES: "readMessage",
   GET_MESSAGES: "getMessage",
   SEND_MESSAGE: "sendMessage",
   DISCONNECT: "disconnect",


### PR DESCRIPTION
# feature : show realtime guestbook upate

## 노션 칸반 링크

- [[socket][Frontend] 새방명록 등록 이벤트 ➡️ 서버 && 서버 ➡️ 갱신된 방명록 배열 받기](https://www.notion.so/vanillacoding/a595c93791e440d78feaa34f9ba6b81b?v=b466274725384ef899a2bc8f94b4b4fa&p=94e3cc3146d44679bf0c1d75cccd97b7)

## 카드에서 구현 혹은 해결하려는 내용
- 새 방명록 입력 시 "sendMessage" emit, "getMessage"이벤트 감지하면 메세지 리스트 state 변경해주기

## 테스트 방법
- 구글, 사파리 브라우저로 각각 다른 아이디로 접속
- 제 3 유저의 마을에 방문하여 방명록이 실시간으로 업데이트 되는지 확인하였습니다.

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/80205036/153869573-e0c2a638-f82c-4acc-af92-7513fc286913.gif)
