### PR TITLE
feature: GuestBook and Send present notification alert

### DIFF
--- a/src/api/guestbook.js
+++ b/src/api/guestbook.js
@@ -26,3 +26,16 @@ export async function leaveNewMessage(townId, message) {
     console.error(error);
   }
 }
+
+export async function changeCheckMessage(loginId) {
+  try {
+    const response = await axios.put(
+      `${process.env.REACT_APP_BASE_URL}/users/${loginId}/guestbook`,
+      { withCredentials: true },
+    );
+
+    return response.data.result;
+  } catch (error) {
+    console.error(error);
+  }
+}

--- a/src/components/FriendProfile/FriendProfile.js
+++ b/src/components/FriendProfile/FriendProfile.js
@@ -5,10 +5,10 @@ import styled from "styled-components";
 const ProfileContainer = styled.div`
   display: flex;
   align-items: center;
-  z-index: 999;
+  z-index: 1;
 
   span {
-    font-size: 18px;
+    font-size: 16px;
   }
 `;
 

--- a/src/components/GameModal/HalfModal.js
+++ b/src/components/GameModal/HalfModal.js
@@ -35,18 +35,20 @@ const StyledHalfContentDiv = styled.div`
   padding: 20px;
 `;
 
-function HalfModal({ category, children }) {
+function HalfModal({ category, children, setIsReceiveGift }) {
   const loginUserId = useSelector(selectUserId);
   const [hasNewPendingFriend, setHasNewPendingFriend] = useState(false);
   const [showFirstContent, setShowFirstContent] = useState(true);
 
   useEffect(async () => {
-    const pendingFriendList = await getPendingFriendList(loginUserId);
-    const isExistNewPendingFriend = pendingFriendList.some(
-      (friend) => !friend.isChecked,
-    );
+    if (category[1] === "친구 요청") {
+      const pendingFriendList = await getPendingFriendList(loginUserId);
+      const isExistNewPendingFriend = pendingFriendList.some(
+        (friend) => !friend.isChecked,
+      );
 
-    setHasNewPendingFriend(isExistNewPendingFriend);
+      setHasNewPendingFriend(isExistNewPendingFriend);
+    }
   });
 
   return (
@@ -60,7 +62,12 @@ function HalfModal({ category, children }) {
         </StyledHalfNavDiv>
         <StyledHalfNavDiv
           checked={!showFirstContent}
-          onClick={() => setShowFirstContent(false)}
+          onClick={() => {
+            if (setIsReceiveGift) {
+              setIsReceiveGift(false);
+            }
+            setShowFirstContent(false);
+          }}
         >
           {category?.[1]}
           {hasNewPendingFriend && <NotificationCircle />}
@@ -80,6 +87,7 @@ function HalfModal({ category, children }) {
 HalfModal.propTypes = {
   category: proptypes.array,
   children: proptypes.array,
+  setIsReceiveGift: proptypes.func,
 };
 
 export default HalfModal;

--- a/src/components/GuestBook/GuestBook.js
+++ b/src/components/GuestBook/GuestBook.js
@@ -9,7 +9,7 @@ import GameModal from "../GameModal/GameModal";
 import MessageInput from "./MessageInput";
 import MessageRow from "./MessageRow";
 import { EVENTS } from "../../constants/socketEvents";
-import { getMessageList } from "../../api/guestbook";
+import { changeCheckMessage, getMessageList } from "../../api/guestbook";
 
 const StyledGuestBookContainer = styled.div`
   height: 350px;
@@ -19,7 +19,7 @@ const StyledGuestBookContainer = styled.div`
   background-color: var(--game-modal-background);
 `;
 
-function GuestBook({ isOpen, toggleGuestbook, socket }) {
+function GuestBook({ isOpen, toggleGuestbook, socket, setIsReceiveGuestBook }) {
   const [messageList, setMessageList] = useState([]);
   const { id } = useParams();
   const userId = useSelector(selectUserId);
@@ -31,6 +31,11 @@ function GuestBook({ isOpen, toggleGuestbook, socket }) {
       const sortedMessages = sortMessages(messages.data.result.guestBook);
 
       setMessageList(sortedMessages);
+
+      if (isMyTown) {
+        await changeCheckMessage(userId);
+        setIsReceiveGuestBook(false);
+      }
     } catch (error) {
       console.error(error);
     }
@@ -57,7 +62,6 @@ function GuestBook({ isOpen, toggleGuestbook, socket }) {
       if (a.date === b.date) return 0;
     });
   }
-
   return (
     <GameModal
       subject="방명록"
@@ -78,6 +82,7 @@ function GuestBook({ isOpen, toggleGuestbook, socket }) {
                 name={post.name}
                 message={post.message}
                 date={post.date}
+                post={post}
               />
             );
           })}
@@ -92,4 +97,5 @@ GuestBook.propTypes = {
   isOpen: proptypes.bool.isRequired,
   toggleGuestbook: proptypes.func.isRequired,
   socket: proptypes.object,
+  setIsReceiveGuestBook: proptypes.func,
 };

--- a/src/components/GuestBook/MessageInput.js
+++ b/src/components/GuestBook/MessageInput.js
@@ -10,11 +10,11 @@ const StyledInputContainer = styled.div`
   align-items: center;
   margin-bottom: 10px;
   width: 100%;
-  background-color: #f5ecdb;
-  border-radius: 10px;
+  background-color: #eae3d5;
+  border-radius: 35px;
 
   input {
-    width: 90%;
+    width: 92%;
     height: 50px;
     font-size: 15px;
     border: 0;
@@ -24,11 +24,13 @@ const StyledInputContainer = styled.div`
   }
 
   .fa-envelope {
-    font-size: 25px;
+    font-size: 22px;
+    color: #c48679;
+    cursor: pointer;
   }
 `;
 
-function MessageInput({ onMessageListUpdate, socket }) {
+function MessageInput({ socket }) {
   const { id } = useParams();
   const messageInput = useRef();
 
@@ -36,9 +38,12 @@ function MessageInput({ onMessageListUpdate, socket }) {
     const messageValue = messageInput.current.value;
 
     try {
-      const { newMessage } = await leaveNewMessage(id, messageValue);
-      socket.emit(EVENTS.SEND_MESSAGE, { townId: id, message: newMessage });
-      messageInput.current.value = "";
+      if (messageValue) {
+        const { newMessage } = await leaveNewMessage(id, messageValue);
+
+        socket.emit(EVENTS.SEND_MESSAGE, { townId: id, message: newMessage });
+        messageInput.current.value = "";
+      }
     } catch (error) {
       console.error(error);
     }
@@ -53,7 +58,6 @@ function MessageInput({ onMessageListUpdate, socket }) {
 }
 
 MessageInput.propTypes = {
-  onMessageListUpdate: proptypes.func.isRequired,
   socket: proptypes.object,
 };
 

--- a/src/components/GuestBook/MessageRow.js
+++ b/src/components/GuestBook/MessageRow.js
@@ -2,49 +2,50 @@ import React from "react";
 import proptypes from "prop-types";
 import styled from "styled-components";
 import { DateTime } from "luxon";
+import FriendProfile from "../FriendProfile/FriendProfile";
 
 const StyledPostContainer = styled.div`
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   align-items: center;
   width: 100%;
-  height: 100px;
-  background: #67d9fd;
+  height: 75px;
+  background: rgba(39, 114, 114, 0.1);
   margin-bottom: 10px;
-  padding: 20px;
-  border-radius: 10px;
+  border-radius: 8px;
 `;
 
 const StyledRightSection = styled.section`
-  flex: 0.4;
-  text-align: center;
-  margin-right: 30px;
+  width: 120px;
+  margin-right: 10px;
+  padding: 16px 5px;
+  border-right: 1px solid #d6f6f6;
 `;
 
-const StyledName = styled.span`
-  font-size: 20px;
-  font-weight: 700;
-  opacity: 0.7;
-`;
 const StyledMessage = styled.span`
   font-size: 15px;
   opacity: 0.7;
 `;
+
 const StyledDate = styled.span`
-  font-size: 12px;
+  font-size: 13px;
   opacity: 0.5;
 `;
 
 const StyledLeftSection = styled.section`
   display: flex;
   flex-direction: column;
+  padding: 5px 5px;
+  width: 320px;
 `;
 
-function MessageRow({ name, message, date }) {
+function MessageRow({ post }) {
+  const { name, message, date, photo } = post;
+
   return (
     <StyledPostContainer>
       <StyledRightSection>
-        <StyledName>{name}</StyledName>
+        <FriendProfile name={name} photo={photo} />
       </StyledRightSection>
       <StyledLeftSection>
         <StyledMessage>{message}</StyledMessage>
@@ -60,4 +61,5 @@ MessageRow.propTypes = {
   name: proptypes.string.isRequired,
   message: proptypes.string.isRequired,
   date: proptypes.string.isRequired,
+  post: proptypes.object,
 };

--- a/src/components/ItemBox/ItemBox.js
+++ b/src/components/ItemBox/ItemBox.js
@@ -1,18 +1,21 @@
 import React from "react";
-import PropTypes from "prop-types";
+import PropTypes, { func } from "prop-types";
 import GameModal from "../GameModal/GameModal";
 import HalfModal from "../GameModal/HalfModal";
 import PresentBox from "./PresentBox";
 import MyItemBox from "./MyItemBox";
 
-function ItemBox({ toggleItemBox, setOutItems }) {
+function ItemBox({ toggleItemBox, setOutItems, setIsReceiveGift }) {
   return (
     <GameModal
       onClose={() => {
         toggleItemBox(false);
       }}
     >
-      <HalfModal category={["내 아이템", "선물함"]}>
+      <HalfModal
+        category={["내 아이템", "선물함"]}
+        setIsReceiveGift={setIsReceiveGift}
+      >
         <MyItemBox onClose={toggleItemBox} setOutItems={setOutItems} />
         <PresentBox onClose={toggleItemBox} setOutItems={setOutItems} />
       </HalfModal>
@@ -25,4 +28,5 @@ export default ItemBox;
 ItemBox.propTypes = {
   toggleItemBox: PropTypes.func.isRequired,
   setOutItems: PropTypes.func,
+  setIsReceiveGift: PropTypes.func,
 };

--- a/src/components/Town/InItemBox.js
+++ b/src/components/Town/InItemBox.js
@@ -8,9 +8,6 @@ const ItemBoxDiv = styled.div`
   width: 90px;
   height: 90px;
   border-radius: 50%;
-  position: absolute;
-  bottom: 100px;
-  right: 45px;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/Town/PostBox.js
+++ b/src/components/Town/PostBox.js
@@ -1,6 +1,9 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
-import proptype from "prop-types";
+import proptype, { bool } from "prop-types";
+import { getMessageList } from "../../api/guestbook";
+import { useSelector } from "react-redux";
+import { selectUserId } from "../../features/user/userSlice";
 
 const PostBoxContainer = styled.div`
   width: 100vw;
@@ -15,9 +18,32 @@ const PostBoxContainer = styled.div`
     image-rendering: pixelated;
     cursor: pointer;
   }
+
+  i {
+    position: absolute;
+    top: 260px;
+    left: 132px;
+    font-size: 17px;
+    color: red;
+  }
 `;
 
-function PostBox({ toggleGuestbook }) {
+function PostBox({
+  toggleGuestbook,
+  isReceiveGuestBook,
+  setIsReceiveGuestBook,
+  isMe,
+}) {
+  const loginUserId = useSelector(selectUserId);
+  // const [isReceiveGuestBook, setIsReceiveGuestBook] = useState(false);
+
+  useEffect(async () => {
+    const response = await getMessageList(loginUserId);
+    const { guestBook } = response.data.result;
+    const isExistNewGuestBook = guestBook.some((msg) => !msg.isChecked);
+    setIsReceiveGuestBook(isExistNewGuestBook);
+  }, []);
+
   return (
     <PostBoxContainer>
       <img
@@ -26,6 +52,9 @@ function PostBox({ toggleGuestbook }) {
         }}
         src="/images/postbox.png"
       />
+      {isMe && isReceiveGuestBook && (
+        <i className="fas fa-exclamation-circle guestBookNoti" />
+      )}
     </PostBoxContainer>
   );
 }
@@ -34,4 +63,7 @@ export default PostBox;
 
 PostBox.propTypes = {
   toggleGuestbook: proptype.func.isRequired,
+  isReceiveGuestBook: proptype.bool,
+  setIsReceiveGuestBook: proptype.func,
+  isMe: proptype.bool,
 };

--- a/src/components/Town/Town.js
+++ b/src/components/Town/Town.js
@@ -49,6 +49,52 @@ const VisitorsContainer = styled.div`
   z-index: 1;
 `;
 
+const GiftAndItemContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-start;
+  width: 200px;
+  height: 170px;
+  position: absolute;
+  bottom: 0;
+  right: 20px;
+
+  .giftNoti {
+    font-size: 22px;
+    color: red;
+    position: absolute;
+    right: -5px;
+  }
+`;
+
+const GuestBookContainer = styled.div`
+  /* display: flex;
+  justify-content: flex-end;
+  align-items: flex-start; */
+  /* width: 400px;
+  height: 500px; */
+  /* position: absolute; */
+  /* bottom: 0;
+  right: 20px; */
+  /* background-color: aliceblue; */
+
+  .guestBookNoti {
+    font-size: 22px;
+    color: red;
+    position: absolute;
+    left: 0;
+  }
+`;
+
+const GuestBookNoti = styled.i`
+  font-size: 22px;
+  color: red;
+  position: absolute;
+  left: 0;
+  z-index: 10;
+  top: 50%;
+`;
+
 function Town({ iceCount, onTownTransition }) {
   const { id } = useParams();
   const [outItems, setOutItems] = useState([]);
@@ -66,6 +112,8 @@ function Town({ iceCount, onTownTransition }) {
   const [targetItem, setTargetItem] = useState("");
   const [onShopFriendList, setOnShopFriendList] = useState(false);
   const [from, setFrom] = useState([]);
+  const [isReceiveGift, setIsReceiveGift] = useState(false);
+  const [isReceiveGuestBook, setIsReceiveGuestBook] = useState(false);
   const socketRef = useRef(null);
 
   useEffect(async () => {
@@ -87,6 +135,7 @@ function Town({ iceCount, onTownTransition }) {
       setFrom([data.from]);
       setNotificationType(TYPE.TYPE_PRESENT);
       setOnNotification(true);
+      setIsReceiveGift(true);
     });
 
     socket.emit(EVENTS.JOIN, { townId: id, user: loginUser });
@@ -106,6 +155,7 @@ function Town({ iceCount, onTownTransition }) {
       socket.off(EVENTS.JOIN);
       socket.off(EVENTS.LEFT);
       socket.off(EVENTS.FRIEND_REQUEST);
+      socket.off(EVENTS.GET_PRESENT);
     };
   }, [id, loginUser.id]);
 
@@ -116,7 +166,6 @@ function Town({ iceCount, onTownTransition }) {
 
     return socketRef.current;
   }
-
   return (
     <>
       <Header
@@ -147,8 +196,21 @@ function Town({ iceCount, onTownTransition }) {
             setOutItems={setOutItems}
           />
         ))}
-        <PostBox toggleGuestbook={setOnPostBox} socket={getSocketIO()} />
-        {isMe && <InItemBox toggleItemBox={setOnItemBoxOpen} />}
+        <PostBox
+          toggleGuestbook={setOnPostBox}
+          isMe={isMe}
+          isReceiveGuestBook={isReceiveGuestBook}
+          setIsReceiveGuestBook={setIsReceiveGuestBook}
+        />
+
+        {isMe && (
+          <GiftAndItemContainer>
+            <InItemBox toggleItemBox={setOnItemBoxOpen} />
+            {isReceiveGift && (
+              <i className="fas fa-exclamation-circle giftNoti" />
+            )}
+          </GiftAndItemContainer>
+        )}
         <ModalPortals>
           {onMail && <Mail toggleMail={setOnMail} />}
           {onPostBox && (
@@ -156,6 +218,7 @@ function Town({ iceCount, onTownTransition }) {
               isOpen={onPostBox}
               toggleGuestbook={setOnPostBox}
               socket={getSocketIO()}
+              setIsReceiveGuestBook={setIsReceiveGuestBook}
             />
           )}
           {onShopOpen && (
@@ -202,6 +265,7 @@ function Town({ iceCount, onTownTransition }) {
             <ItemBox
               toggleItemBox={setOnItemBoxOpen}
               setOutItems={setOutItems}
+              setIsReceiveGift={setIsReceiveGift}
             />
           )}
         </ModalPortals>


### PR DESCRIPTION
# feature/notification

## 노션 칸반 링크

- [새로운 방명록, 선물함 알림 띄우기](https://www.notion.so/vanillacoding/09a3eb1667c348eaae38c4dca4c7beea)

## 카드에서 구현 혹은 해결하려는 내용

- 새로운 방명록이 추가되면 우체통 옆에 빨간 알림이 띄워지고, 마을 주인이 방명록을 확인하면 알림이 꺼진다.
- 새로운 선물이 오면 선물함을 들어가서 확인하기 전까지 빨간 알림이 뜬다.

## 테스트 방법
- 다른 유저에게 선물하면 실시간으로 선물도착 모달이 띄워지고 선물함에 들어가서 확인하기 전까지 빨간 알림이 아이템함에 떠있음
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/80485020/154130561-0dfd605c-d36d-4cde-9f42-6a904d5f6cdf.gif)

## 기타사항
- 선물함은 실시간으로 빨간 알림이 뜨지만 방명록은 실시간으로 소켓이 이루어지는 부분이 방명록창을 켜고 있을때라 방명록을 키고 있지 않으면 다시 한번 렌더됐을때 켜지는 이슈가 있습니다.
