### PR TITLE
fix: set socket init component to town, devided socket event by dependencies

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,8 +13,6 @@ function App() {
   const { user } = useSelector((state) => state.user);
 
   useEffect(() => {
-    const socket = getSocketIO();
-
     return () => {
       socket.disconnect();
     };
@@ -41,7 +39,7 @@ function App() {
             />
             <Route
               path="/users/:id"
-              element={<Town socket={getSocketIO()} />}
+              element={<Town socketInit={getSocketIO} />}
             />
           </Route>
         </Route>


### PR DESCRIPTION
# fix: set socket init component to town, devided socket event by dependencies

![image](https://user-images.githubusercontent.com/80205036/154412526-154e105d-8c43-4d73-b696-cff85a46c9ca.png)

## 구현 사항
- 로그인시에는 socket 연결이 필요치 않음에도, 소켓 connect 요청이 서버로 전송되고 있음을 확인 -> init 함수를 타운 컴포넌트의 프롭으로 내려서 타운이 render 되었을 때 연결시도 하는 것으로 flow 변경 
- 타운 id에 따라 join, left 이벤트가 발생하므로 dependency 별로 타운의 useEfffect 분리 작업 진행
