### PR TITLE
fix: add route for privacy-policy

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Login from "./components/Login/Login";
 import Town from "./components/Town/Town";
 import RequireAuth from "./components/RequireAuth/RequireAuth";
 import PersistLogin from "./components/PersistLogin/PersistLogin";
+import PrivacyPolicy from "./components/PrivacyPolicy/PrivacyPolicy";
 import { ToastContainer } from "react-toastify";
 
 function App() {
@@ -55,6 +56,7 @@ function App() {
             />
           </Route>
         </Route>
+        <Route path="/privacy-policy" element={<PrivacyPolicy />} />
         <Route path="*" element={<div>Error</div>} />
       </Routes>
     </>

--- a/src/components/PrivacyPolicy/PrivacyPolicy.js
+++ b/src/components/PrivacyPolicy/PrivacyPolicy.js
@@ -1,0 +1,10 @@
+const EXTERNAL_URL_PRIVACY_POLICIES =
+  "https://www.privacypolicies.com/live/fea10eb9-79bb-4a3c-805a-845a79f53d81";
+
+function PrivacyPolicy() {
+  window.location.href = EXTERNAL_URL_PRIVACY_POLICIES;
+
+  return null;
+}
+
+export default PrivacyPolicy;


### PR DESCRIPTION
# fix: add route for privacy-policy

## 카드에서 구현 혹은 해결하려는 내용
<img width="579" alt="image" src="https://user-images.githubusercontent.com/80205036/161364084-91b80c74-0d8d-4644-a771-654e97dfc3ea.png">

- Google 앱 인증 관련해서 도메인 인증이 필요하다는 답변을 받았습니다. [privacypolicies.com](http://privacypolicies.com/) 은 외부 도메인이기 때문에 폴라타운 도메인에서 리다이렉트 될 수 있도록 PrivacyPolicy 컴포넌트 작성하여 Route를 추가해 주었습니다.
